### PR TITLE
Fix jquery selector for new gist format.

### DIFF
--- a/lib/jquery.code-callout.js
+++ b/lib/jquery.code-callout.js
@@ -499,7 +499,8 @@ License: https://raw.github.com/djleeds/code-callout/master/LICENSE.md
 		"gist": {
 			options: {
 				getLineSelector: function(listingId, lineNumber) {
-					return "#" + listingId + " .line-data .line:nth-child(" + lineNumber + ")";
+                        return "#" + listingId + " td[data-line-number='" + lineNumber + "'] + td";
+
 				}
 			}
 		},


### PR DESCRIPTION
Hi @djleeds I tested the selector I put in the commit in a standalone HTML page without code callout. It complies with the new gist format below (extracted from one of my simplest gist).

I have tried to simply change the selector with mine in code callout in the `gist` profile in the `getLineSelector` method but it did not work.
As I'm not a frontend dev at all, and I have no time to learn, can you please do the last steps ?


```<div id="gist101698995" class="gist">
    <div class="gist-file">
      <div class="gist-data">
        <div class="js-gist-file-update-container js-task-list-container file-box">
  <div id="file-decodeusingbeamcodercreation-java" class="file">
    

  <div itemprop="text" class="Box-body p-0 blob-wrapper data type-java ">
      
<table class="highlight tab-size js-file-line-container" data-tab-size="8" data-paste-markdown-skip>
      <tr>
        <td id="file-decodeusingbeamcodercreation-java-L1" class="blob-num js-line-number" data-line-number="1"></td>
        <td id="file-decodeusingbeamcodercreation-java-LC1" class="blob-code blob-code-inner js-file-line"> <span class="pl-k">new</span> <span class="pl-k">DecodeUsingBeamCoder&lt;&gt;</span>(</td>
      </tr>
      <tr>
        <td id="file-decodeusingbeamcodercreation-java-L2" class="blob-num js-line-number" data-line-number="2"></td>
        <td id="file-decodeusingbeamcodercreation-java-LC2" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">new</span> <span class="pl-smi">Cast</span>(<span class="pl-k">new</span> <span class="pl-smi">GetColumnByOrdinal</span>(<span class="pl-c1">0</span>, <span class="pl-smi">BinaryType</span>), <span class="pl-smi">BinaryType</span>), classTag, coder),</td>
      </tr>
      <tr>
        <td id="file-decodeusingbeamcodercreation-java-L3" class="blob-num js-line-number" data-line-number="3"></td>
        <td id="file-decodeusingbeamcodercreation-java-LC3" class="blob-code blob-code-inner js-file-line">        classTag);</td>
      </tr>
</table>


  </div>

  </div>
</div>

      </div>
      <div class="gist-meta">
        <a href="https://gist.github.com/echauchot/63a80c85f486f067e5b2df10e045718d/raw/041c0740a8e271e82466ab6f13e727c7dbf15daf/DecodeUsingBeamCoderCreation.java" style="float:right">view raw</a>
        <a href="https://gist.github.com/echauchot/63a80c85f486f067e5b2df10e045718d#file-decodeusingbeamcodercreation-java">DecodeUsingBeamCoderCreation.java</a>
        hosted with &#10084; by <a href="https://github.com">GitHub</a>
      </div>
    </div>
</div>